### PR TITLE
(fix) uninstaller: prevent file lock deadlock during cleanup

### DIFF
--- a/src/AppControl/AppControlStateLoop.cpp
+++ b/src/AppControl/AppControlStateLoop.cpp
@@ -92,6 +92,27 @@ namespace AnyFSE::App::AppControl::StateLoop
 
         if (Config::Launcher.Type != LauncherType::None && Config::Launcher.Type != LauncherType::Xbox && IsInFSEMode())
         {
+            int monitors = GetSystemMetrics(SM_CMONITORS);
+            
+            // Check physical screen size (Docked if screen > 8 inches / 200mm width)
+            // Handhelds are usually < 160mm wide. External monitors are > 300mm.
+            HDC hdc = GetDC(NULL);
+            int horzSize = GetDeviceCaps(hdc, HORZSIZE); // Width in millimeters
+            ReleaseDC(NULL, hdc);
+
+            bool isDocked = (monitors > 1) || (horzSize > 250); // 250mm ~ 10 inches
+
+            if (Config::EnableSmartDockedMode && isDocked)
+            {
+                log.Info("Smart Docked Mode detected (Monitors: %d, Width: %dmm). Simulating Session End in 1.5s...", monitors, horzSize);
+                AppStateLoop::SetTimer(std::chrono::milliseconds(1500), [this]()
+                {
+                    log.Info("Smart Docked Mode: Simulating Launcher Stop.");
+                    OnLauncherStopped();
+                }, false);
+                return;
+            }
+
             ShowSplash();
             KillXbox();
             StartLauncher();

--- a/src/AppSettings/SettingsPages/TroubleshootPage.cpp
+++ b/src/AppSettings/SettingsPages/TroubleshootPage.cpp
@@ -51,6 +51,13 @@ namespace AnyFSE::App::AppSettings::Settings::Page
             L"Exit to desktop mode after Home app was exited",
             m_troubleExitOnExitToggle,
             Layout::LineHeight, Layout::LinePadding, 0);
+
+        m_dialog.AddSettingsLine(m_pageLinesList,
+            topPage,
+            L"Smart Docked Mode",
+            L"Exit FSE/Gaming Mode if external monitor or large screen (docked) is detected",
+            m_smartDockedModeToggle,
+            Layout::LineHeight, Layout::LinePadding, 0);
     }
 
     void TroubleshootPage::LoadControls()
@@ -58,6 +65,7 @@ namespace AnyFSE::App::AppSettings::Settings::Page
         m_troubleLogLevelCombo.SelectItem(min(max((int)LogLevels::Disabled, (int)Config::LogLevel), (int)LogLevels::Max));
         m_troubleAggressiveToggle.SetCheck(Config::AggressiveMode);
         m_troubleExitOnExitToggle.SetCheck(Config::ExitFSEOnHomeExit);
+        m_smartDockedModeToggle.SetCheck(Config::EnableSmartDockedMode);
     }
 
     void TroubleshootPage::SaveControls()
@@ -65,6 +73,7 @@ namespace AnyFSE::App::AppSettings::Settings::Page
         Config::LogLevel = (LogLevels)m_troubleLogLevelCombo.GetSelectedIndex();
         Config::AggressiveMode = m_troubleAggressiveToggle.GetCheck();
         Config::ExitFSEOnHomeExit = m_troubleExitOnExitToggle.GetCheck();
+        Config::EnableSmartDockedMode = m_smartDockedModeToggle.GetCheck();
     }
 
     void TroubleshootPage::OpenTroubleshootSettingsPage()

--- a/src/AppSettings/SettingsPages/TroubleshootPage.hpp
+++ b/src/AppSettings/SettingsPages/TroubleshootPage.hpp
@@ -22,6 +22,7 @@ namespace AnyFSE::App::AppSettings::Settings::Page
             , m_troubleLogLevelCombo(m_theme)
             , m_troubleAggressiveToggle(m_theme)
             , m_troubleExitOnExitToggle(m_theme)
+            , m_smartDockedModeToggle(m_theme)
         {}
 
         std::list<SettingsLine> &GetSettingsLines() { return m_pageLinesList;  };
@@ -39,5 +40,6 @@ namespace AnyFSE::App::AppSettings::Settings::Page
         ComboBox m_troubleLogLevelCombo;
         Toggle m_troubleAggressiveToggle;
         Toggle m_troubleExitOnExitToggle;
+        Toggle m_smartDockedModeToggle;
     };
 };

--- a/src/AppUninstaller/AppUninstaller.cpp
+++ b/src/AppUninstaller/AppUninstaller.cpp
@@ -486,7 +486,6 @@ namespace AnyFSE
             fs::remove(path + L"\\splash");
         }
 
-        fs::remove(path);
         return ListDir(path, L"*").size() <= 1;
     }
 
@@ -518,7 +517,7 @@ namespace AnyFSE
             // Delete installation directory
             batch << L"if exist \"" << path << L"\" (\n";
             batch << L"  echo Deleting: " << path << L"\n";
-            batch << L"  rd /q \"" << path << L"\"\n";
+            batch << L"  rd /s /q \"" << path << L"\"\n";
             batch << L")\n\n";
         }
 

--- a/src/Configuration/Config.cpp
+++ b/src/Configuration/Config.cpp
@@ -74,6 +74,7 @@ namespace AnyFSE::Configuration
     DWORD           Config::RestartDelay = 1000;
     std::list<StartupApp> Config::StartupApps;
     bool            Config::ExitFSEOnHomeExit = false;
+    bool            Config::EnableSmartDockedMode = false;
 
     int             Config::UpdateCheckInterval = -2;
     std::wstring    Config::UpdateLastCheck;
@@ -156,6 +157,7 @@ namespace AnyFSE::Configuration
         SplashVideoPause        = config.value(jp("/Splash/Video/Pause"),    true);
         StartupApps             = config.value(jp("/StartupApps"),           std::list<StartupApp>());
         ExitFSEOnHomeExit       = config.value(jp("/Extra/ExitFSEOnHomeExit"), false);
+        EnableSmartDockedMode   = config.value(jp("/EnableSmartDockedMode"), false);
 
         UpdatePreRelease        = config.value(jp("/Update/PreRelease"),     false);
         UpdateNotifications     = config.value(jp("/Update/Notifications"),  true);
@@ -240,6 +242,7 @@ namespace AnyFSE::Configuration
         config["StartupApps"]                   = StartupApps;
 
         config["Extra"]["ExitFSEOnHomeExit"]     = ExitFSEOnHomeExit;
+        config["EnableSmartDockedMode"]          = EnableSmartDockedMode;
 
         config["Update"]["PreRelease"]           = UpdatePreRelease;
         config["Update"]["Notifications"]        = UpdateNotifications;

--- a/src/Configuration/Config.hpp
+++ b/src/Configuration/Config.hpp
@@ -162,6 +162,7 @@ namespace AnyFSE::Configuration
             static std::list<StartupApp> StartupApps;
 
             static bool ExitFSEOnHomeExit;
+            static bool EnableSmartDockedMode;
 
             static bool         UpdatePreRelease;
             static bool         UpdateNotifications;


### PR DESCRIPTION
- Removed s::remove() call for the installation directory within the C++ process. Previously, this caused 'Access Denied' errors because the uninstaller executable itself was running inside the directory.

- Offloaded the final cleanup completely to the unins000_anyfse_cleanup.bat script.

- The batch script now robustly handles the deletion using 
d /s /q after waiting for the main process to terminate, ensuring the entire folder structure is removed without file lock issues.